### PR TITLE
feat: drop support of php < 8, drop support of symfony < 5.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 8.0
+  - 8.1
 
 sudo: false
 
@@ -12,15 +11,17 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  - SYMFONY_VERSION=3.3.*
+  - SYMFONY_VERSION=5.4.*
 
 matrix:
   include:
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-    - php: 5.6
+    - php: 8.0
+      env: SYMFONY_VERSION=5.4.*
+    - php: 8.1
+      env: SYMFONY_VERSION=6.0.*
+    - php: 8.1
+      env: SYMFONY_VERSION=6.1.*
+    - php: 8.0
       env: COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -13,23 +13,21 @@ This bundle allows creating and managing backups in a Symfony application. It is
 
 ## Installation
 
-Require this bundle with composer:
+1. Install with composer:
 
-    composer require zenstruck/backup-bundle
+        $ composer require zenstruck/backup-bundle
 
-Then enable it in your kernel:
+2. Enable the bundle:
+   This Step is only needed if you are not using [Symfony Flex](https://symfony.com/doc/current/setup/flex.html).
 
-```php
-// app/AppKernel.php
-public function registerBundles()
-{
-    $bundles = array(
-        //...
-        new Zenstruck\BackupBundle\ZenstruckBackupBundle(),
-        //...
-    );
-}
-```
+    ```php
+    // config/bundles.php
+
+    return [
+            // ...
+            Zenstruck\BackupBundle\ZenstruckBackupBundle::class => ['all' => true],
+        ];
+    ```
 
 ## Configuration
 
@@ -45,7 +43,7 @@ zenstruck_backup:
                 database: my_database
         files:
             rsync:
-                source: "%kernel.root_dir%/../web/files"
+                source: "%kernel.project_dir%/public/files"
                 additional_options:
                     - --exclude=_cache/
     namers:
@@ -64,7 +62,7 @@ zenstruck_backup:
                 bucket: "s3://foobar/backups"
     profiles:
         daily:
-            scratch_dir: "%kernel.root_dir%/cache/backup"
+            scratch_dir: "%kernel.project_dir%/cache/backup"
             sources: [database, files]
             namer: daily
             processor: zip
@@ -89,18 +87,18 @@ Options:
 **NOTES**:
 
 1. Add `-vv` to see the log.
-2. For long running backups, it may be required to increase the `memory_limit` in your `app/console`/`bin/console`.
+2. For long running backups, it may be required to increase the `memory_limit` in your `bin/console`.
 3. Running the command without a profile will list available profiles.
 
 Examples (with the above configuration):
 
 * Create a backup at: `s3://foobar/backups/mysite-{day-of-month}`
 
-        app/console zenstruck:backup:run daily
+        bin/console zenstruck:backup:run daily
 
 * Create a backup at: `s3://foobar/backups/mysite-{YYYYMMDDHHMMSS}`
 
-        app/console zenstruck:backup:run snapshot
+        bin/console zenstruck:backup:run snapshot
 
 ### List Existing Backups
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "zenstruck/backup-bundle",
-    "description": "Symfony2 Bundle that wraps backup commands",
-    "keywords": ["symfony2", "bundle", "backup"],
-    "homepage": "http://zenstruck.com/projects/ZenstruckBackupBundle",
+    "description": "Symfony Bundle that wraps backup commands",
+    "keywords": ["symfony", "bundle", "backup"],
+    "homepage": "https://zenstruck.com/projects/ZenstruckBackupBundle",
     "type": "symfony-bundle",
     "license": "MIT",
     "authors": [
@@ -12,15 +12,16 @@
         }
     ],
     "require": {
-        "zenstruck/backup": "^1.1.1",
-        "symfony/framework-bundle": "~2.3|~3.0"
+        "php": ">=8.0",
+        "zenstruck/backup": "dev-master#bacff4f",
+        "symfony/framework-bundle": "^5.4|^6.0"
     },
     "require-dev": {
-        "symfony/console": "~2.3|~3.0",
-        "symfony/yaml": "~2.3|~3.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^1.1",
-        "sebastian/exporter": "^2.0",
-        "phpunit/phpunit": "^5.7"
+        "symfony/console": "^5.4|^6.0",
+        "symfony/yaml": "^5.4|^6.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.3",
+        "sebastian/exporter": "^4.0",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": { "Zenstruck\\BackupBundle\\": "src/" }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="ZenstruckBackupBundle Test Suite">
-            <directory suffix="Test.php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="ZenstruckBackupBundle Test Suite">
+      <directory suffix="Test.php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -16,7 +16,7 @@ class ListCommand extends BaseListCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var Application $application */
         $application = $this->getApplication();
@@ -32,6 +32,6 @@ class ListCommand extends BaseListCommand
             $container->get('zenstruck_backup.executor')
         ));
 
-        parent::execute($input, $output);
+        return parent::execute($input, $output);
     }
 }

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -16,7 +16,7 @@ class RunCommand extends BaseRunCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var Application $application */
         $application = $this->getApplication();
@@ -32,6 +32,6 @@ class RunCommand extends BaseRunCommand
             $container->get('zenstruck_backup.executor')
         ));
 
-        parent::execute($input, $output);
+        return parent::execute($input, $output);
     }
 }

--- a/src/DependencyInjection/Compiler/DestinationCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DestinationCompilerPass.php
@@ -7,26 +7,17 @@ namespace Zenstruck\BackupBundle\DependencyInjection\Compiler;
  */
 class DestinationCompilerPass extends RegisterCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefinitionName()
+    protected function getDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.destination';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addDestination';
     }

--- a/src/DependencyInjection/Compiler/NamerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/NamerCompilerPass.php
@@ -7,26 +7,17 @@ namespace Zenstruck\BackupBundle\DependencyInjection\Compiler;
  */
 class NamerCompilerPass extends RegisterCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefinitionName()
+    protected function getDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.namer';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addNamer';
     }

--- a/src/DependencyInjection/Compiler/ProcessorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ProcessorCompilerPass.php
@@ -7,26 +7,17 @@ namespace Zenstruck\BackupBundle\DependencyInjection\Compiler;
  */
 class ProcessorCompilerPass extends RegisterCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefinitionName()
+    protected function getDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.processor';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addProcessor';
     }

--- a/src/DependencyInjection/Compiler/ProfileCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ProfileCompilerPass.php
@@ -7,26 +7,17 @@ namespace Zenstruck\BackupBundle\DependencyInjection\Compiler;
  */
 class ProfileCompilerPass extends RegisterCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefinitionName()
+    protected function getDefinitionName(): string
     {
         return 'zenstruck_backup.profile_registry';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.profile';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'add';
     }

--- a/src/DependencyInjection/Compiler/RegisterCompilerPass.php
+++ b/src/DependencyInjection/Compiler/RegisterCompilerPass.php
@@ -30,18 +30,9 @@ abstract class RegisterCompilerPass implements CompilerPassInterface
         }
     }
 
-    /**
-     * @return string
-     */
-    abstract protected function getDefinitionName();
+    abstract protected function getDefinitionName(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getTagName();
+    abstract protected function getTagName(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getMethodName();
+    abstract protected function getMethodName(): string;
 }

--- a/src/DependencyInjection/Compiler/SourceCompilerPass.php
+++ b/src/DependencyInjection/Compiler/SourceCompilerPass.php
@@ -7,26 +7,17 @@ namespace Zenstruck\BackupBundle\DependencyInjection\Compiler;
  */
 class SourceCompilerPass extends RegisterCompilerPass
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getDefinitionName()
+    protected function getDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.source';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addSource';
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,29 +12,23 @@ use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
  */
 class Configuration implements ConfigurationInterface
 {
-    private $namerFactories;
-    private $processorFactories;
-    private $sourceFactories;
-    private $destinationFactories;
-
     /**
      * @param Factory[] $namerFactories
      * @param Factory[] $processorFactories
      * @param Factory[] $sourceFactories
      * @param Factory[] $destinationFactories
      */
-    public function __construct(array $namerFactories, array $processorFactories, array $sourceFactories, array $destinationFactories)
+    public function __construct(private array $namerFactories,
+                                private array $processorFactories,
+                                private array $sourceFactories,
+                                private array $destinationFactories)
     {
-        $this->namerFactories = $namerFactories;
-        $this->processorFactories = $processorFactories;
-        $this->sourceFactories = $sourceFactories;
-        $this->destinationFactories = $destinationFactories;
     }
 
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('zenstruck_backup');
+        $treeBuilder = new TreeBuilder('zenstruck_backup');
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addFactories($rootNode, 'namers', 'namer', $this->namerFactories);
         $this->addFactories($rootNode, 'processors', 'processor', $this->processorFactories);
@@ -81,53 +75,30 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    /**
-     * @param string $id
-     *
-     * @return Factory
-     */
-    public function getSourceFactory($id)
+    public function getSourceFactory(string $id): Factory
     {
         return $this->sourceFactories[$id];
     }
 
-    /**
-     * @param string $id
-     *
-     * @return Factory
-     */
-    public function getNamerFactory($id)
+    public function getNamerFactory(string $id): Factory
     {
         return $this->namerFactories[$id];
     }
 
-    /**
-     * @param string $id
-     *
-     * @return Factory
-     */
-    public function getDestinationFactory($id)
+    public function getDestinationFactory(string $id): Factory
     {
         return $this->destinationFactories[$id];
     }
 
-    /**
-     * @param string $id
-     *
-     * @return Factory
-     */
-    public function getProcessorFactory($id)
+    public function getProcessorFactory(string $id): Factory
     {
         return $this->processorFactories[$id];
     }
 
     /**
-     * @param ArrayNodeDefinition $node
-     * @param string              $plural
-     * @param string              $singular
      * @param Factory[]           $factories
      */
-    private function addFactories(ArrayNodeDefinition $node, $plural, $singular, array $factories)
+    private function addFactories(ArrayNodeDefinition $node, string $plural, string $singular, array $factories)
     {
         $nodeBuilder = $node
             ->children()

--- a/src/DependencyInjection/Factory/Destination/FlysystemDestinationFactory.php
+++ b/src/DependencyInjection/Factory/Destination/FlysystemDestinationFactory.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Destination;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 
@@ -13,10 +13,7 @@ use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
  */
 class FlysystemDestinationFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'flysystem';
     }
@@ -24,11 +21,11 @@ class FlysystemDestinationFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.destination.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.destination.abstract_flysystem'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.destination.abstract_flysystem'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, new Reference($config['filesystem_service']))
             ->addTag('zenstruck_backup.destination')

--- a/src/DependencyInjection/Factory/Destination/S3CmdDestinationFactory.php
+++ b/src/DependencyInjection/Factory/Destination/S3CmdDestinationFactory.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Destination;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 use Zenstruck\Backup\Destination\S3CmdDestination;
@@ -14,10 +14,7 @@ use Zenstruck\Backup\Destination\S3CmdDestination;
  */
 class S3CmdDestinationFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 's3cmd';
     }
@@ -25,11 +22,11 @@ class S3CmdDestinationFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.destination.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.destination.abstract_s3cmd'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.destination.abstract_s3cmd'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, $config['bucket'])
             ->replaceArgument(2, $config['timeout'])

--- a/src/DependencyInjection/Factory/Destination/StreamDestinationFactory.php
+++ b/src/DependencyInjection/Factory/Destination/StreamDestinationFactory.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Destination;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 
@@ -13,10 +13,7 @@ use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
  */
 class StreamDestinationFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'stream';
     }
@@ -24,11 +21,11 @@ class StreamDestinationFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.destination.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.destination.abstract_stream'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.destination.abstract_stream'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, $config['directory'])
             ->addTag('zenstruck_backup.destination')

--- a/src/DependencyInjection/Factory/Factory.php
+++ b/src/DependencyInjection/Factory/Factory.php
@@ -11,26 +11,19 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 interface Factory
 {
-    /**
-     * @return string
-     */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Creates the reference, registers it and returns a reference.
      *
      * @param ContainerBuilder $container A ContainerBuilder instance
-     * @param string           $id        The id of the service
+     * @param string $id        The id of the service
      * @param array            $config    An array of configuration
-     *
-     * @return Reference
      */
-    public function create(ContainerBuilder $container, $id, array $config);
+    public function create(ContainerBuilder $container, string $id, array $config): Reference;
 
     /**
      * Adds configuration nodes for the factory.
-     *
-     * @param ArrayNodeDefinition $builder
      */
     public function addConfiguration(ArrayNodeDefinition $builder);
 }

--- a/src/DependencyInjection/Factory/Namer/SimpleNamerFactory.php
+++ b/src/DependencyInjection/Factory/Namer/SimpleNamerFactory.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Namer;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 use Zenstruck\Backup\Namer\SimpleNamer;
@@ -14,10 +14,7 @@ use Zenstruck\Backup\Namer\SimpleNamer;
  */
 class SimpleNamerFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'simple';
     }
@@ -25,11 +22,11 @@ class SimpleNamerFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.namer.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.namer.abstract_simple'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.namer.abstract_simple'))
             ->replaceArgument(0, $config['name'])
             ->addTag('zenstruck_backup.namer')
         ;

--- a/src/DependencyInjection/Factory/Namer/TimestampNamerFactory.php
+++ b/src/DependencyInjection/Factory/Namer/TimestampNamerFactory.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Namer;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 use Zenstruck\Backup\Namer\TimestampNamer;
@@ -14,10 +14,7 @@ use Zenstruck\Backup\Namer\TimestampNamer;
  */
 class TimestampNamerFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'timestamp';
     }
@@ -25,11 +22,11 @@ class TimestampNamerFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.namer.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.namer.abstract_timestamp'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.namer.abstract_timestamp'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, $config['format'])
             ->replaceArgument(2, $config['prefix'])

--- a/src/DependencyInjection/Factory/Processor/GzipArchiveProcessorFactory.php
+++ b/src/DependencyInjection/Factory/Processor/GzipArchiveProcessorFactory.php
@@ -3,9 +3,10 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Processor;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
+use Zenstruck\Backup\Processor\ArchiveProcessor;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 use Zenstruck\Backup\Processor\GzipArchiveProcessor;
 
@@ -14,10 +15,7 @@ use Zenstruck\Backup\Processor\GzipArchiveProcessor;
  */
 class GzipArchiveProcessorFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'gzip';
     }
@@ -25,11 +23,11 @@ class GzipArchiveProcessorFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.processor.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.processor.abstract_gzip'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.processor.abstract_gzip'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, $config['options'])
             ->replaceArgument(2, $config['timeout'])
@@ -47,7 +45,7 @@ class GzipArchiveProcessorFactory implements Factory
         $builder
             ->children()
                 ->scalarNode('options')->defaultValue(GzipArchiveProcessor::DEFAULT_OPTIONS)->end()
-                ->integerNode('timeout')->defaultValue(GzipArchiveProcessor::DEFAULT_TIMEOUT)->end()
+                ->integerNode('timeout')->defaultValue(ArchiveProcessor::DEFAULT_TIMEOUT)->end()
             ->end()
         ;
     }

--- a/src/DependencyInjection/Factory/Processor/ZipArchiveProcessorFactory.php
+++ b/src/DependencyInjection/Factory/Processor/ZipArchiveProcessorFactory.php
@@ -3,9 +3,10 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Processor;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
+use Zenstruck\Backup\Processor\ArchiveProcessor;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 use Zenstruck\Backup\Processor\ZipArchiveProcessor;
 
@@ -14,10 +15,7 @@ use Zenstruck\Backup\Processor\ZipArchiveProcessor;
  */
 class ZipArchiveProcessorFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'zip';
     }
@@ -25,11 +23,11 @@ class ZipArchiveProcessorFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.processor.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.processor.abstract_zip'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.processor.abstract_zip'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, $config['options'])
             ->replaceArgument(2, $config['timeout'])
@@ -47,7 +45,7 @@ class ZipArchiveProcessorFactory implements Factory
         $builder
             ->children()
                 ->scalarNode('options')->defaultValue(ZipArchiveProcessor::DEFAULT_OPTIONS)->end()
-                ->integerNode('timeout')->defaultValue(ZipArchiveProcessor::DEFAULT_TIMEOUT)->end()
+                ->integerNode('timeout')->defaultValue(ArchiveProcessor::DEFAULT_TIMEOUT)->end()
             ->end()
         ;
     }

--- a/src/DependencyInjection/Factory/Source/MySqlDumpSourceFactory.php
+++ b/src/DependencyInjection/Factory/Source/MySqlDumpSourceFactory.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Source;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 use Zenstruck\Backup\Source\MySqlDumpSource;
@@ -14,10 +14,7 @@ use Zenstruck\Backup\Source\MySqlDumpSource;
  */
 class MySqlDumpSourceFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'mysqldump';
     }
@@ -25,11 +22,11 @@ class MySqlDumpSourceFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.source.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.source.abstract_mysqldump'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.source.abstract_mysqldump'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, $config['database'])
             ->replaceArgument(2, $config['host'])

--- a/src/DependencyInjection/Factory/Source/RsyncSourceFactory.php
+++ b/src/DependencyInjection/Factory/Source/RsyncSourceFactory.php
@@ -3,8 +3,8 @@
 namespace Zenstruck\BackupBundle\DependencyInjection\Factory\Source;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Zenstruck\BackupBundle\DependencyInjection\Factory\Factory;
 use Zenstruck\Backup\Source\RsyncSource;
@@ -14,10 +14,7 @@ use Zenstruck\Backup\Source\RsyncSource;
  */
 class RsyncSourceFactory implements Factory
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'rsync';
     }
@@ -25,11 +22,11 @@ class RsyncSourceFactory implements Factory
     /**
      * {@inheritdoc}
      */
-    public function create(ContainerBuilder $container, $id, array $config)
+    public function create(ContainerBuilder $container, string $id, array $config): Reference
     {
         $serviceId = sprintf('zenstruck_backup.source.%s', $id);
 
-        $container->setDefinition($serviceId, new DefinitionDecorator('zenstruck_backup.source.abstract_rsync'))
+        $container->setDefinition($serviceId, new ChildDefinition('zenstruck_backup.source.abstract_rsync'))
             ->replaceArgument(0, $id)
             ->replaceArgument(1, $config['source'])
             ->replaceArgument(2, $config['additional_options'])

--- a/tests/Command/ListCommandTest.php
+++ b/tests/Command/ListCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Zenstruck\BackupBundle\Tests\Command;
 
+use Zenstruck\Backup\Console\Command\ProfileActionCommand;
 use Zenstruck\BackupBundle\Command\ListCommand;
 
 /**
@@ -9,18 +10,12 @@ use Zenstruck\BackupBundle\Command\ListCommand;
  */
 class ListCommandTest extends ProfileActionCommandTest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function createCommand()
+    protected function createCommand(): ListCommand|ProfileActionCommand
     {
         return new ListCommand();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCommandName()
+    protected function getCommandName(): string
     {
         return 'zenstruck:backup:list';
     }

--- a/tests/Command/ProfileActionCommandTest.php
+++ b/tests/Command/ProfileActionCommandTest.php
@@ -2,10 +2,13 @@
 
 namespace Zenstruck\BackupBundle\Tests\Command;
 
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\Console\Application as FrameworkApplication;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Zenstruck\Backup\Console\Command\ProfileActionCommand;
 use Zenstruck\Backup\Executor;
 use Zenstruck\Backup\ProfileRegistry;
@@ -13,16 +16,15 @@ use Zenstruck\Backup\ProfileRegistry;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-abstract class ProfileActionCommandTest extends \PHPUnit_Framework_TestCase
+abstract class ProfileActionCommandTest extends TestCase
 {
     /**
      * @test
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No profiles configured.
      */
     public function it_can_execute()
     {
+        $this->expectExceptionMessage("No profiles configured.");
+        $this->expectException(\RuntimeException::class);
         $registry = new ProfileRegistry();
         $executor = new Executor(new NullLogger());
 
@@ -50,26 +52,24 @@ abstract class ProfileActionCommandTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     *
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Application must be instance of Symfony\Bundle\FrameworkBundle\Console\Application
      */
     public function it_fails_with_wrong_application()
     {
-        $application = new Application($this->createMock('Symfony\Component\DependencyInjection\ContainerInterface'));
+        $this->expectExceptionMessage("Application must be instance of Symfony\Bundle\FrameworkBundle\Console\Application");
+        $this->expectException(\RuntimeException::class);
+
+        # TODO is this Change correct ? Useful anymore?
+        /** @var ContainerInterface&MockObject $container */
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+
+        $application = new Application("avc");
         $application->add($this->createCommand());
 
         $tester = new CommandTester($application->find($this->getCommandName()));
         $tester->execute(array('command' => $this->getCommandName()));
     }
 
-    /**
-     * @return ProfileActionCommand
-     */
-    abstract protected function createCommand();
+    abstract protected function createCommand(): ProfileActionCommand;
 
-    /**
-     * @return string
-     */
-    abstract protected function getCommandName();
+    abstract protected function getCommandName(): string;
 }

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -9,18 +9,12 @@ use Zenstruck\BackupBundle\Command\RunCommand;
  */
 class RunCommandTest extends ProfileActionCommandTest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function createCommand()
+    protected function createCommand(): RunCommand
     {
         return new RunCommand();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCommandName()
+    protected function getCommandName(): string
     {
         return 'zenstruck:backup:run';
     }

--- a/tests/DependencyInjection/Compiler/DestinationCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/DestinationCompilerPassTest.php
@@ -10,26 +10,17 @@ use Zenstruck\BackupBundle\DependencyInjection\Compiler\DestinationCompilerPass;
  */
 class DestinationCompilerPassTest extends RegisterCompilerPassTest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRegistrarDefinitionName()
+    protected function getRegistrarDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.destination';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addDestination';
     }
@@ -37,7 +28,7 @@ class DestinationCompilerPassTest extends RegisterCompilerPassTest
     /**
      * {@inheritdoc}
      */
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new DestinationCompilerPass());
     }

--- a/tests/DependencyInjection/Compiler/NamerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/NamerCompilerPassTest.php
@@ -10,34 +10,22 @@ use Zenstruck\BackupBundle\DependencyInjection\Compiler\NamerCompilerPass;
  */
 class NamerCompilerPassTest extends RegisterCompilerPassTest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRegistrarDefinitionName()
+    protected function getRegistrarDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.namer';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addNamer';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new NamerCompilerPass());
     }

--- a/tests/DependencyInjection/Compiler/ProcessorCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ProcessorCompilerPassTest.php
@@ -10,26 +10,17 @@ use Zenstruck\BackupBundle\DependencyInjection\Compiler\ProcessorCompilerPass;
  */
 class ProcessorCompilerPassTest extends RegisterCompilerPassTest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRegistrarDefinitionName()
+    protected function getRegistrarDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.processor';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addProcessor';
     }
@@ -37,7 +28,7 @@ class ProcessorCompilerPassTest extends RegisterCompilerPassTest
     /**
      * {@inheritdoc}
      */
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ProcessorCompilerPass());
     }

--- a/tests/DependencyInjection/Compiler/ProfileCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ProfileCompilerPassTest.php
@@ -10,26 +10,17 @@ use Zenstruck\BackupBundle\DependencyInjection\Compiler\ProfileCompilerPass;
  */
 class ProfileCompilerPassTest extends RegisterCompilerPassTest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRegistrarDefinitionName()
+    protected function getRegistrarDefinitionName(): string
     {
         return 'zenstruck_backup.profile_registry';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.profile';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'add';
     }
@@ -37,7 +28,7 @@ class ProfileCompilerPassTest extends RegisterCompilerPassTest
     /**
      * {@inheritdoc}
      */
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ProfileCompilerPass());
     }

--- a/tests/DependencyInjection/Compiler/RegisterCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/RegisterCompilerPassTest.php
@@ -32,18 +32,9 @@ abstract class RegisterCompilerPassTest extends AbstractCompilerPassTestCase
         );
     }
 
-    /**
-     * @return string
-     */
-    abstract protected function getRegistrarDefinitionName();
+    abstract protected function getRegistrarDefinitionName(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getTagName();
+    abstract protected function getTagName(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getMethodName();
+    abstract protected function getMethodName(): string;
 }

--- a/tests/DependencyInjection/Compiler/SourceCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/SourceCompilerPassTest.php
@@ -10,26 +10,17 @@ use Zenstruck\BackupBundle\DependencyInjection\Compiler\SourceCompilerPass;
  */
 class SourceCompilerPassTest extends RegisterCompilerPassTest
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRegistrarDefinitionName()
+    protected function getRegistrarDefinitionName(): string
     {
         return 'zenstruck_backup.profile_builder';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTagName()
+    protected function getTagName(): string
     {
         return 'zenstruck_backup.source';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getMethodName()
+    protected function getMethodName(): string
     {
         return 'addSource';
     }
@@ -37,7 +28,7 @@ class SourceCompilerPassTest extends RegisterCompilerPassTest
     /**
      * {@inheritdoc}
      */
-    protected function registerCompilerPass(ContainerBuilder $container)
+    protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new SourceCompilerPass());
     }

--- a/tests/DependencyInjection/ZenstruckBackupExtensionTest.php
+++ b/tests/DependencyInjection/ZenstruckBackupExtensionTest.php
@@ -50,26 +50,27 @@ class ZenstruckBackupExtensionTest extends AbstractExtensionTestCase
      *
      * @dataProvider invalidConfigProvider
      */
-    public function compile_with_invalid_config($file, $message, $expectedException)
+    public function compile_with_invalid_config(string $file, string $message, string $expectedException)
     {
-        $this->setExpectedException($expectedException, $message);
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($message);
 
         $this->load($this->loadConfig($file));
         $this->compile();
     }
 
-    public static function invalidConfigProvider()
+    public static function invalidConfigProvider(): array
     {
-        return array(
-            array('invalid_profile_missing_sources.yml', 'The child node "sources" at path "zenstruck_backup.profiles.daily" must be configured.', 'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'),
-            array('invalid_profile_missing_namer.yml', 'The child node "namer" at path "zenstruck_backup.profiles.daily" must be configured.', 'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'),
-            array('invalid_profile_missing_destinations.yml', 'The child node "destinations" at path "zenstruck_backup.profiles.daily" must be configured.', 'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'),
-        );
+        return [
+            ['invalid_profile_missing_sources.yml', 'The child config "sources" under "zenstruck_backup.profiles.daily" must be configured.', 'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'],
+            ['invalid_profile_missing_namer.yml', 'The child config "namer" under "zenstruck_backup.profiles.daily" must be configured.', 'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'],
+            ['invalid_profile_missing_destinations.yml', 'The child config "destinations" under "zenstruck_backup.profiles.daily" must be configured.', 'Symfony\Component\Config\Definition\Exception\InvalidConfigurationException'],
+        ];
     }
 
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
-        return array(new ZenstruckBackupExtension());
+        return [new ZenstruckBackupExtension()];
     }
 
     private function loadConfig($file)

--- a/tests/Fixtures/invalid_profile_missing_destinations.yml
+++ b/tests/Fixtures/invalid_profile_missing_destinations.yml
@@ -1,6 +1,6 @@
 profiles:
     daily:
-        scratch_dir: "%kernel.root_dir%/cache/backup"
+        scratch_dir: "%kernel.project_dir%/cache/backup"
         sources: [database]
         namer: daily
         processor: zip

--- a/tests/Fixtures/invalid_profile_missing_namer.yml
+++ b/tests/Fixtures/invalid_profile_missing_namer.yml
@@ -1,6 +1,6 @@
 profiles:
     daily:
-        scratch_dir: "%kernel.root_dir%/cache/backup"
+        scratch_dir: "%kernel.project_dir%/cache/backup"
         sources: [database]
         processor: zip
         destinations: s3

--- a/tests/Fixtures/invalid_profile_missing_sources.yml
+++ b/tests/Fixtures/invalid_profile_missing_sources.yml
@@ -1,6 +1,6 @@
 profiles:
     daily:
-        scratch_dir: "%kernel.root_dir%/cache/backup"
+        scratch_dir: "%kernel.project_dir%/cache/backup"
         namer: daily
         processor: zip
         destinations: s3

--- a/tests/Fixtures/valid_config.yml
+++ b/tests/Fixtures/valid_config.yml
@@ -4,7 +4,7 @@ sources:
             database: my_database
     files:
         rsync:
-            source: "%kernel.root_dir%/../web/files"
+            source: "%kernel.project_dir%/public/files"
             additional_options:
                 - --exclude=_cache/
 namers:
@@ -32,13 +32,13 @@ destinations:
             directory: /foo
 profiles:
     daily:
-        scratch_dir: "%kernel.root_dir%/cache/backup"
+        scratch_dir: "%kernel.project_dir%/cache/backup"
         sources: [database, files]
         namer: daily
         processor: zip
         destinations: s3
     monthly:
-        scratch_dir: "%kernel.root_dir%/cache/backup"
+        scratch_dir: "%kernel.project_dir%/cache/backup"
         sources: files
         namer: daily
         processor: zip

--- a/tests/ZenstruckBackupBundleTest.php
+++ b/tests/ZenstruckBackupBundleTest.php
@@ -2,12 +2,18 @@
 
 namespace Zenstruck\BackupBundle\Tests;
 
+use PHPUnit\Framework\TestCase;
+use Zenstruck\BackupBundle\DependencyInjection\Compiler\DestinationCompilerPass;
+use Zenstruck\BackupBundle\DependencyInjection\Compiler\NamerCompilerPass;
+use Zenstruck\BackupBundle\DependencyInjection\Compiler\ProcessorCompilerPass;
+use Zenstruck\BackupBundle\DependencyInjection\Compiler\ProfileCompilerPass;
+use Zenstruck\BackupBundle\DependencyInjection\Compiler\SourceCompilerPass;
 use Zenstruck\BackupBundle\ZenstruckBackupBundle;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-class ZenstruckBackupBundleTest extends \PHPUnit_Framework_TestCase
+class ZenstruckBackupBundleTest extends TestCase
 {
     /**
      * @test
@@ -23,11 +29,11 @@ class ZenstruckBackupBundleTest extends \PHPUnit_Framework_TestCase
             ->expects($this->exactly(5))
             ->method('addCompilerPass')
             ->withConsecutive(
-                $this->isInstanceOf('Zenstruck\BackupBundle\DependencyInjection\Compiler\ProfileCompilerPass'),
-                $this->isInstanceOf('Zenstruck\BackupBundle\DependencyInjection\Compiler\DestinationCompilerPass'),
-                $this->isInstanceOf('Zenstruck\BackupBundle\DependencyInjection\Compiler\SourceCompilerPass'),
-                $this->isInstanceOf('Zenstruck\BackupBundle\DependencyInjection\Compiler\ProcessorCompilerPass'),
-                $this->isInstanceOf('Zenstruck\BackupBundle\DependencyInjection\Compiler\NamerCompilerPass')
+                [$this->isInstanceOf(ProfileCompilerPass::class)],
+                [$this->isInstanceOf(DestinationCompilerPass::class)],
+                [$this->isInstanceOf(SourceCompilerPass::class)],
+                [$this->isInstanceOf(ProcessorCompilerPass::class)],
+                [$this->isInstanceOf(NamerCompilerPass::class)]
             );
 
         $bundle = new ZenstruckBackupBundle();


### PR DESCRIPTION
add support symfony 6
https://github.com/kbond/ZenstruckBackupBundle/issues/14

See https://github.com/kbond/php-backup/pull/16

My tests rely on the included test. I did not test it in a real life application.